### PR TITLE
utilize newer saml2aws and allow for non-profile usecases

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ zinit snippet https://github.com/onyxraven/zsh-saml2aws/blob/master/zsh-saml2aws
 
 ## Aliases
 
-In any case `<exec-profile>` is available in a shortcut alias below, it is positional, but optional. If you do not specify a profile, it will use the 'base' role you have assumed. For these commands, any extra parameters are passed to `saml2aws`, so use `--` to separate your flags from a command.
+In any case `<exec-profile>` is available in a shortcut alias below, it is positional, but optional. If you do not specify a profile, it will use the 'base' role you have assumed. For these commands, any extra parameters are passed to `saml2aws`, so use `--` to separate your flags from a command. Each of the commands with a profile also have autocompletion from your loaded `~/.aws/config` file enabled.
 
 | Alias | parameters                 | description                                                                   |
 | ----- | -------------------------- | ----------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 oh-my-zsh plugin for [saml2aws](https://github.com/Versent/saml2aws)
 
+## Requirements
+
+* [saml2aws](https://github.com/Versent/saml2aws) >= 2.23 (?)
+* [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) >= 2
+* zsh as your shell
+
 ## Installation
 
 ### [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)

--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ oh-my-zsh plugin for [saml2aws](https://github.com/Versent/saml2aws)
 
 ## Installation
 
-### Prerequisites
-
-You do need the following installed. These are OSX defaults, so this should be no surprise.
-
-- python (2 or 3)
-- curl
-
 ### [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh)
 
 This plugin is intended to be used with oh-my-zsh
@@ -32,64 +25,36 @@ plugins=(
 1. add `zgen load onyxraven/zsh-saml2aws` to your '!saved/save' block
 1. `zgen update`
 
-## Features
+### [zinit](https://github.com/zdharma-continuum/zinit)
 
-This plugin is pretty simple - it provides:
+Use it like other oh-my-zsh plugins.
 
-- aliases
+```bash
+zinit snippet https://github.com/onyxraven/zsh-saml2aws/blob/master/zsh-saml2aws.plugin.zsh
+```
 
-### Aliases
+## Aliases
+
+In any case `<exec-profile>` is available in a shortcut alias below, it is positional, but optional. If you do not specify a profile, it will use the 'base' role you have assumed. For these commands, any extra parameters are passed to `saml2aws`, so use `--` to separate your flags from a command.
 
 | Alias | parameters                 | description                                                                   |
 | ----- | -------------------------- | ----------------------------------------------------------------------------- |
 | sa    |                            | saml2aws command shortcut alias                                               |
-| sal   |                            | login to IDP (skips prompts by default)                                       |
-| sae   | \<exec-profile> \<command> | execute a command as the profile                                              |
-| sash  | \<exec-profile>            | open a shell as the profile                                                   |
+| sal   |                            | login to IDP (skips prompts by default, and uses the session duration var)    |
+| sae   | \<exec-profile> \<command> | execute a command as the profile, with the session duration var               |
+| sash  | \<exec-profile>            | open a shell as the profile, with the session duration var                    |
+| sas   | \<exec-profile>            | print shell export script for profile, with the session duration var          |
+| sase  | \<exec-profile>            | print env file format for profile, with the session duration var              |
 | salr  |                            | list roles available to login as                                              |
-| sac   |                            | Open a browser to the logged in AWS console                                   |
+| sac   | \<exec-profile>            | Open a browser to the logged in AWS console                                   |
 | said  |                            | output of `aws sts get-caller-identity` for assumed role (\$profile optional) |
 
 ## saml2aws configuration
 
-| ENV var                         | example                     | information                                                                                                                                               |
-| ------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SAML2AWS_LOGIN_SESSION_DURATION | 43200                       | Length of time (seconds) the "root" federation session is available. This can be up to 12 hours.                                                          |
-| SAML2AWS_SESSION_DURATION       | 3600                        | Length of time (seconds) the role assume session is available. This will always be <= 1 hour.                                                             |
-| SAML2AWS_MFA                    | OLP                         | Name of the MFA device to use. When unspecified, you will be prompted if there are many, and that is the string to put here. OneLogin Protect for example |
-| SAML2AWS_ROLE                   | arn:aws:iam::$ID:role/$ROLE | ARN of the role to federate to. When unspecified, you will be prompted if there are many.                                                                 |
-| SAML2AWS_PROFILE                | saml                        | aws cli profile (in `~/.aws/config`) to use. `saml` by default.                                                                                           |
-| SAML2AWS_URL                    | https://api.us.onelogin.com | http url to IDP, OneLogin for example.                                                                                                                    |
-
-## script helper configuration
-
-| ENV var             | example           | information                                                                                     |
-| ------------------- | ----------------- | ----------------------------------------------------------------------------------------------- |
-| AWS_DEFAULT_REGION  | us-east-1         | Default console region                                                                          |
-| SAML2AWS_PL_BROWSER | com.google.chrome | set the browser opened for `sac`. By default will use your system default browser if available. |
-
-### sac - console login in private browsing window
-
-> This alias is currently only supported in OSX.
-
-This alias will open a new browser window after getting the temporary login URL for your federated login.
-
-You can specify a specific browser to handle your login URL by setting `SAML2AWS_PL_BROWSER` to the bundle name of the
-browser. By default, it will pick your default URL handler in MacOS. It supports the following browsers:
-
-| `SAML2AWS_PL_BROWSER` value | Browser | Description                                                                                                                               |
-| --------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `org.mozilla.firefox`       | Firefox | Creates and/or opens a profile with the same name as your aws-vault profile. This allows for multiple profiles to be open simultaneously. |
-| `com.google.chrome`         | Chrome  | Opens a new private browsing window for the session. This allows for multiple profiles to be open simultaneously.                         |
-
-## TODO
-
-- [ ] list exec-profile names available (via ~/.aws/config)
-- [ ] login url to get directly to an assumed role
-  - at least, to the 'share' url. must parse profile (python?)
-- [ ] exec without exec-profile ?
-- [ ] prompt segment
-- [ ] replace curl with python? or replace python.
+| ENV var                         | example | information                                                                                                   |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| SAML2AWS_LOGIN_SESSION_DURATION | 43200   | Length of time (seconds) the "root" federation session is available. This can be up to 12 hours (in seconds). |
+| SAML2AWS_SESSION_DURATION       | 3600    | Length of time (seconds) the role assume session is available. This can be up to 1 hour (in seconds).         |
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ In any case `<exec-profile>` is available in a shortcut alias below, it is posit
 | SAML2AWS_LOGIN_SESSION_DURATION | 43200   | Length of time (seconds) the "root" federation session is available. This can be up to 12 hours (in seconds). |
 | SAML2AWS_SESSION_DURATION       | 3600    | Length of time (seconds) the role assume session is available. This can be up to 1 hour (in seconds).         |
 
+## Examples
+
+Assume the `staging` profile and run an aws command
+
+```sh
+sae staging -- aws sts get-caller-identity
+```
+
+Assume the login role and start a shell (same as you are using) with that context
+
+```sh
+sash
+```
+
 ## Thanks
 
 - Inspired by [zsh-aws-vault](https://github.com/blimmer/zsh-aws-vault)

--- a/zsh-saml2aws.plugin.zsh
+++ b/zsh-saml2aws.plugin.zsh
@@ -61,7 +61,7 @@ function sase() {
 # Completions                                                        #
 #--------------------------------------------------------------------#
 
-compctl -K _saml2aws_profiles sae sash said sac sase
+compdef _saml2aws_profiles sae sash said sac sase
 
 #--------------------------------------------------------------------#
 # Private Functions                                                  #
@@ -76,4 +76,5 @@ function _saml2aws_profiles_string() {
 
 function _saml2aws_profiles() {
   reply=($(_saml2aws_profiles_string))
+  _arguments "1::AWS profile:($reply)"
 }

--- a/zsh-saml2aws.plugin.zsh
+++ b/zsh-saml2aws.plugin.zsh
@@ -9,15 +9,20 @@ alias sa='saml2aws'
 alias salr="saml2aws list-roles --skip-prompt"
 
 function sal() {
-  saml2aws login --skip-prompt --session-duration=$SAML2AWS_LOGIN_SESSION_DURATION "$@"
+  saml2aws login --skip-prompt --session-duration="$SAML2AWS_LOGIN_SESSION_DURATION" "$@"
 }
 
 function sae() {
-  old_profile=$SAML2AWS_EXEC_PROFILE_ACTIVE
-  export SAML2AWS_EXEC_PROFILE_ACTIVE=$1
-  shift
-  saml2aws exec --session-duration=$SAML2AWS_SESSION_DURATION --exec-profile "$SAML2AWS_EXEC_PROFILE_ACTIVE" "$@"
-  export SAML2AWS_EXEC_PROFILE_ACTIVE=$old_profile
+  profile=$1
+  if [[ ! -z "$profile" && ! "$profile" =~ ^-- ]]; then
+    old_profile="$SAML2AWS_EXEC_PROFILE_ACTIVE"
+    export SAML2AWS_EXEC_PROFILE_ACTIVE="$profile"
+    shift
+    saml2aws exec --session-duration="$SAML2AWS_SESSION_DURATION" --exec-profile="$SAML2AWS_EXEC_PROFILE_ACTIVE" "$@"
+    export SAML2AWS_EXEC_PROFILE_ACTIVE="$old_profile"
+  else
+    saml2aws exec --session-duration="$SAML2AWS_SESSION_DURATION" "$@"
+  fi
 }
 
 function sash() {
@@ -33,78 +38,21 @@ function said() {
 }
 
 function sac() {
-  local login_url
-  login_url="$(_saml2aws_getSigninTokenUrl)"
+  profile=$1
+  if [[ ! -z "$profile" ]]; then shift; fi
+  saml2aws console --exec-profile "$profile" "$@"
+}
 
-  profile=${1:-$SAML2AWS_PROFILE}
-  profile=${profile:-saml}
+function sas() {
+  sase "$@" | sed -e 's/^/export /'
+}
 
-  if [ $? -ne 0 ]; then
-    echo "Could not login" >&2
-    return 1
-  fi
-
-  if _saml2aws_using_osx ; then
-    local browser="$(_saml2aws_find_browser)"
-
-    case $browser in
-      org.mozilla.firefox)
-        # Ensure a profile is created (can run idempotently) and launch it as a disowned process
-        /Applications/Firefox.app/Contents/MacOS/firefox --CreateProfile $1 2>/dev/null && \
-        /Applications/Firefox.app/Contents/MacOS/firefox --no-remote -P $1 "${login_url}" 2>/dev/null &!
-        ;;
-      com.google.chrome)
-        echo "${login_url}" | xargs -t nohup /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome %U --no-first-run --new-window --disk-cache-dir=$(mktemp -d /tmp/chrome.XXXXXX) --user-data-dir=$(mktemp -d /tmp/chrome.XXXXXX) > /dev/null 2>&1 &!
-        ;;
-      *)
-        open -a Safari "${login_url}"
-        ;;
-    esac
-
+function sase() {
+  profile=$1
+  if [[ ! -z "$profile" && ! "$profile" =~ ^-- ]]; then
+    shift;
+    sae "$profile" env "$@" | grep '^AWS_\(SESSION_TOKEN\|ACCESS_KEY_ID\|SECRET_ACCESS_KEY\|CREDENTIAL_EXPIRATION\)'
   else
-    # NOTE this is untested - PRs welcome to improve it.
-    echo "${login_url}" | xargs xdg-open
-  fi
-}
-
-#--------------------------------------------------------------------#
-# Utility Functions                                                  #
-#--------------------------------------------------------------------#
-
-function _saml2aws_urlencode() {
-  echo $1 | python -c 'import urllib, sys; sys.stdout.writelines(urllib.quote_plus(l, safe="/\n") for l in sys.stdin)'
-}
-
-function _saml2aws_getSigninTokenUrl() {
-  session=$( (eval $(saml2aws script); sh -c 'echo "{\"sessionId\": \"$AWS_ACCESS_KEY_ID\",\"sessionKey\":\"$AWS_SECRET_ACCESS_KEY\",\"sessionToken\":\"$AWS_SECURITY_TOKEN\"}"') )
-  signinToken=$(curl -s -G https://signin.aws.amazon.com/federation --data-urlencode "Action=getSigninToken" --data-urlencode "SessionDuration=43200" --data-urlencode "Session=$session" | python -c "import json,sys; print json.load(sys.stdin)['SigninToken']")
-
-  if [[ -z "$signinToken" ]]; then
-    echo "Could not sign in with current profile." >&2
-    exit 1
-  fi
-
-  consoleUrl=$(_saml2aws_urlencode "https://console.aws.amazon.com/console/home?region=$AWS_DEFAULT_REGION")
-
-  echo "https://signin.aws.amazon.com/federation?Action=login&Issuer=$(_saml2aws_urlencode $SAML2AWS_URL)&Destination=$consoleUrl&SigninToken=$signinToken"
-}
-
-
-function _saml2aws_using_osx() {
-  [[ $(uname) == "Darwin" ]]
-}
-
-function _saml2aws_find_browser() {
-  if [ -n "$SAML2AWS_PL_BROWSER" ]; then
-    # use the browser bundle specified
-    echo "$SAML2AWS_PL_BROWSER"
-  elif _saml2aws_using_osx ; then
-    # Detect the browser in launchservices
-    # https://stackoverflow.com/a/32465364/808678
-    local prefs=~/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist
-    plutil -convert xml1 $prefs -o - \
-      | grep 'https' -b3 $prefs | awk 'NR==2 {split($2, arr, "[><]"); print arr[3]}';
-  else
-    # TODO - other platforms
+    saml2aws script --shell=env "$@"
   fi
 }

--- a/zsh-saml2aws.plugin.zsh
+++ b/zsh-saml2aws.plugin.zsh
@@ -56,3 +56,24 @@ function sase() {
     saml2aws script --shell=env "$@"
   fi
 }
+
+#--------------------------------------------------------------------#
+# Completions                                                        #
+#--------------------------------------------------------------------#
+
+compctl -K _saml2aws_profiles sae sash said sac sase
+
+#--------------------------------------------------------------------#
+# Private Functions                                                  #
+#--------------------------------------------------------------------#
+
+# Note this was lifted from the oh-my-zsh plugin https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/aws/aws.plugin.zsh
+function _saml2aws_profiles_string() {
+  aws --no-cli-pager configure list-profiles 2> /dev/null && return
+  [[ -r "${AWS_CONFIG_FILE:-$HOME/.aws/config}" ]] || return 1
+  grep --color=never -Eo '\[.*\]' "${AWS_CONFIG_FILE:-$HOME/.aws/config}" | sed -E 's/^[[:space:]]*\[(profile)?[[:space:]]*([^[:space:]]+)\][[:space:]]*$/\2/g'
+}
+
+function _saml2aws_profiles() {
+  reply=($(_saml2aws_profiles_string))
+}


### PR DESCRIPTION
* switch console to use the saml2aws console native (much simpler)
* add `script` aliases for env vars output
* enable using (all?) commands without a second profile, assumes the rest of the args are `--` prefixed, including separating the commands for `exec`